### PR TITLE
Fix test failure on Windows

### DIFF
--- a/pkg/oras/oras_test.go
+++ b/pkg/oras/oras_test.go
@@ -98,7 +98,7 @@ func (suite *ORASTestSuite) Test_0_Push() {
 			if err != nil {
 				return err
 			}
-			contents[filename] = content
+			contents[filepath.ToSlash(filename)] = content
 		}
 		return nil
 	}


### PR DESCRIPTION
Test fails on Windows due to Unix/Linux file delimiters.