### PR TITLE
push to / pull from content store

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,10 +128,9 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/shizhMSFT/oras/pkg/content"
-
 	"github.com/containerd/containerd/remotes/docker"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/shizhMSFT/oras/pkg/content"
 	"github.com/shizhMSFT/oras/pkg/oras"
 )
 

--- a/README.md
+++ b/README.md
@@ -127,9 +127,11 @@ package main
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+
+	"github.com/shizhMSFT/oras/pkg/content"
 
 	"github.com/containerd/containerd/remotes/docker"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/shizhMSFT/oras/pkg/oras"
 )
 
@@ -141,30 +143,27 @@ func check(e error) {
 
 func main() {
 	ref := "localhost:5000/oras:test"
-	fileName := "hi.txt"
+	fileName := "hello.txt"
 	fileContent := []byte("Hello World!\n")
-	customMediaType := "application/vnd.me.hi"
+	customMediaType := "my.custom.media.type"
 
 	ctx := context.Background()
 	resolver := docker.NewResolver(docker.ResolverOptions{})
 
 	// Push file(s) w custom mediatype to registry
-	pushContents := make(map[string]oras.Blob)
-	pushContents[fileName] = oras.Blob{
-		Content: fileContent,
-		MediaType: customMediaType,
-	}
+	memoryStore := content.NewMemoryStore()
+	desc := memoryStore.Add(fileName, customMediaType, fileContent)
+	pushContents := []ocispec.Descriptor{desc}
 	fmt.Printf("Pushing %s to %s... ", fileName, ref)
-	err := oras.Push(ctx, resolver, ref, pushContents)
+	err := oras.Push(ctx, resolver, ref, memoryStore, pushContents)
 	check(err)
 	fmt.Println("success!")
 
 	// Pull file(s) from registry and save to disk
 	fmt.Printf("Pulling from %s and saving to %s... ", ref, fileName)
+	fileStore := content.NewFileStore("")
 	allowedMediaTypes := []string{customMediaType}
-	pullContents, err := oras.Pull(ctx, resolver, ref, allowedMediaTypes...)
-	check(err)
-	err = ioutil.WriteFile(fileName, pullContents[fileName].Content, 0644)
+	_, err = oras.Pull(ctx, resolver, ref, fileStore, allowedMediaTypes...)
 	check(err)
 	fmt.Println("success!")
 	fmt.Printf("Try running 'cat %s'\n", fileName)

--- a/examples/simple_push_pull.go
+++ b/examples/simple_push_pull.go
@@ -4,10 +4,9 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/shizhMSFT/oras/pkg/content"
-
 	"github.com/containerd/containerd/remotes/docker"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/shizhMSFT/oras/pkg/content"
 	"github.com/shizhMSFT/oras/pkg/oras"
 )
 

--- a/pkg/content/consts.go
+++ b/pkg/content/consts.go
@@ -1,4 +1,4 @@
-package oras
+package content
 
 import ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 

--- a/pkg/content/errors.go
+++ b/pkg/content/errors.go
@@ -1,0 +1,8 @@
+package content
+
+import "errors"
+
+// Common errors
+var (
+	ErrNotFound = errors.New("not_found")
+)

--- a/pkg/content/errors.go
+++ b/pkg/content/errors.go
@@ -4,5 +4,7 @@ import "errors"
 
 // Common errors
 var (
-	ErrNotFound = errors.New("not_found")
+	ErrNotFound        = errors.New("not_found")
+	ErrNoName          = errors.New("no_name")
+	ErrUnsupportedSize = errors.New("unsupported_size")
 )

--- a/pkg/content/file.go
+++ b/pkg/content/file.go
@@ -2,36 +2,47 @@ package content
 
 import (
 	"context"
+	"io"
 	"os"
+	"path/filepath"
 	"sync"
+	"time"
 
 	"github.com/containerd/containerd/content"
+	"github.com/containerd/containerd/errdefs"
 	digest "github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/pkg/errors"
 )
 
 // ensure interface
 var (
-	_ content.Provider = &FileProvider{}
+	_ content.Provider = &FileStore{}
+	_ content.Ingester = &FileStore{}
 )
 
-// FileProvider provides content from the file system
-type FileProvider struct {
+// FileStore provides content from the file system
+type FileStore struct {
+	root       string
 	descriptor *sync.Map // map[string]ocispec.Descriptor
 }
 
 // NewFileProvider creats a new file provider
-func NewFileProvider() *FileProvider {
-	return nil
+func NewFileProvider(rootPath string) *FileStore {
+	return &FileStore{
+		root:       rootPath,
+		descriptor: &sync.Map{},
+	}
 }
 
 // Add adds a file reference
-func (p *FileProvider) Add(filename, mediaType string) error {
-	fileInfo, err := os.Stat(filename)
+func (s *FileStore) Add(name, mediaType string) error {
+	path := s.resolvePath(name)
+	fileInfo, err := os.Stat(path)
 	if err != nil {
 		return err
 	}
-	file, err := os.Open(filename)
+	file, err := os.Open(path)
 	if err != nil {
 		return err
 	}
@@ -46,23 +57,26 @@ func (p *FileProvider) Add(filename, mediaType string) error {
 		Digest:    digest,
 		Size:      fileInfo.Size(),
 		Annotations: map[string]string{
-			ocispec.AnnotationTitle: filename,
+			ocispec.AnnotationTitle: name,
 		},
 	}
 
-	p.descriptor.Store(desc.Digest, desc)
+	s.set(desc)
 	return nil
 }
 
 // ReaderAt provides contents
-func (p *FileProvider) ReaderAt(ctx context.Context, desc ocispec.Descriptor) (content.ReaderAt, error) {
-	value, ok := p.descriptor.Load(desc.Digest)
+func (s *FileStore) ReaderAt(ctx context.Context, desc ocispec.Descriptor) (content.ReaderAt, error) {
+	desc, ok := s.get(desc)
 	if !ok {
 		return nil, ErrNotFound
 	}
-	desc = value.(ocispec.Descriptor)
-	filename := desc.Annotations[ocispec.AnnotationTitle]
-	file, err := os.Open(filename)
+	name, ok := s.resolveName(desc)
+	if !ok {
+		return nil, ErrNoName
+	}
+	path := s.resolvePath(name)
+	file, err := os.Open(path)
 	if err != nil {
 		return nil, err
 	}
@@ -71,4 +85,154 @@ func (p *FileProvider) ReaderAt(ctx context.Context, desc ocispec.Descriptor) (c
 		readAtCloser: file,
 		size:         desc.Size,
 	}, nil
+}
+
+// Writer begins or resumes the active writer identified by desc
+func (s *FileStore) Writer(ctx context.Context, opts ...content.WriterOpt) (content.Writer, error) {
+	var wOpts content.WriterOpts
+	for _, opt := range opts {
+		if err := opt(&wOpts); err != nil {
+			return nil, err
+		}
+	}
+	desc := wOpts.Desc
+
+	name, ok := s.resolveName(desc)
+	if !ok {
+		return nil, ErrNoName
+	}
+	path := s.resolvePath(name)
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		return nil, err
+	}
+
+	file, err := os.Create(path)
+	if err != nil {
+		return nil, err
+	}
+
+	now := time.Now()
+	return &fileWriter{
+		store:    s,
+		file:     file,
+		desc:     desc,
+		digester: digest.Canonical.Digester(),
+		status: content.Status{
+			Ref:       name,
+			Total:     desc.Size,
+			StartedAt: now,
+			UpdatedAt: now,
+		},
+	}, nil
+}
+
+func (s *FileStore) resolveName(desc ocispec.Descriptor) (string, bool) {
+	name, ok := desc.Annotations[ocispec.AnnotationTitle]
+	return name, ok
+}
+
+func (s *FileStore) resolvePath(path string) string {
+	if filepath.IsAbs(path) {
+		return path
+	}
+	return filepath.Join(s.root, path)
+}
+
+func (s *FileStore) set(desc ocispec.Descriptor) {
+	s.descriptor.Store(desc.Digest, desc)
+}
+
+func (s *FileStore) get(desc ocispec.Descriptor) (ocispec.Descriptor, bool) {
+	value, ok := s.descriptor.Load(desc.Digest)
+	if !ok {
+		return ocispec.Descriptor{}, false
+	}
+	desc, ok = value.(ocispec.Descriptor)
+	return desc, ok
+}
+
+type fileWriter struct {
+	store    *FileStore
+	file     *os.File
+	desc     ocispec.Descriptor
+	digester digest.Digester
+	status   content.Status
+}
+
+func (w *fileWriter) Status() (content.Status, error) {
+	return w.status, nil
+}
+
+// Digest returns the current digest of the content, up to the current write.
+//
+// Cannot be called concurrently with `Write`.
+func (w *fileWriter) Digest() digest.Digest {
+	return w.digester.Digest()
+}
+
+// Write p to the transaction.
+func (w *fileWriter) Write(p []byte) (n int, err error) {
+	n, err = w.file.Write(p)
+	w.digester.Hash().Write(p[:n])
+	w.status.Offset += int64(len(p))
+	w.status.UpdatedAt = time.Now()
+	return n, err
+}
+
+func (w *fileWriter) Commit(ctx context.Context, size int64, expected digest.Digest, opts ...content.Opt) error {
+	var base content.Info
+	for _, opt := range opts {
+		if err := opt(&base); err != nil {
+			return err
+		}
+	}
+
+	if w.file == nil {
+		return errors.Wrap(errdefs.ErrFailedPrecondition, "cannot commit on closed writer")
+	}
+	fileInfo, err := w.file.Stat()
+	if err != nil {
+		w.Close()
+		return errors.Wrap(err, "stat failed")
+	}
+	if err := w.Close(); err != nil {
+		return errors.Wrap(err, "failed to close file")
+	}
+
+	if size > 0 && size != fileInfo.Size() {
+		return errors.Wrapf(errdefs.ErrFailedPrecondition, "unexpected commit size %d, expected %d", fileInfo.Size(), size)
+	}
+	if dgst := w.digester.Digest(); expected != "" && expected != dgst {
+		return errors.Wrapf(errdefs.ErrFailedPrecondition, "unexpected commit digest %s, expected %s", dgst, expected)
+	}
+
+	return nil
+}
+
+// Close the writer, flushing any unwritten data and leaving the progress in
+// tact.
+func (w *fileWriter) Close() error {
+	if w.file == nil {
+		return nil
+	}
+
+	file := w.file
+	w.file = nil
+	if err := file.Sync(); err != nil {
+		file.Close()
+		return errors.Wrap(err, "sync failed")
+	}
+	return file.Close()
+}
+
+func (w *fileWriter) Truncate(size int64) error {
+	if size != 0 {
+		return ErrUnsupportedSize
+	}
+	w.status.Offset = 0
+	w.digester.Hash().Reset()
+	if _, err := w.file.Seek(0, io.SeekStart); err != nil {
+		return err
+	}
+	return w.file.Truncate(0)
 }

--- a/pkg/content/file.go
+++ b/pkg/content/file.go
@@ -71,7 +71,7 @@ func (s *FileStore) ReaderAt(ctx context.Context, desc ocispec.Descriptor) (cont
 	if !ok {
 		return nil, ErrNotFound
 	}
-	name, ok := resolveName(desc)
+	name, ok := ResolveName(desc)
 	if !ok {
 		return nil, ErrNoName
 	}
@@ -97,7 +97,7 @@ func (s *FileStore) Writer(ctx context.Context, opts ...content.WriterOpt) (cont
 	}
 	desc := wOpts.Desc
 
-	name, ok := resolveName(desc)
+	name, ok := ResolveName(desc)
 	if !ok {
 		return nil, ErrNoName
 	}

--- a/pkg/content/file.go
+++ b/pkg/content/file.go
@@ -206,6 +206,7 @@ func (w *fileWriter) Commit(ctx context.Context, size int64, expected digest.Dig
 		return errors.Wrapf(errdefs.ErrFailedPrecondition, "unexpected commit digest %s, expected %s", dgst, expected)
 	}
 
+	w.store.set(w.desc)
 	return nil
 }
 

--- a/pkg/content/file.go
+++ b/pkg/content/file.go
@@ -1,0 +1,74 @@
+package content
+
+import (
+	"context"
+	"os"
+	"sync"
+
+	"github.com/containerd/containerd/content"
+	digest "github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+// ensure interface
+var (
+	_ content.Provider = &FileProvider{}
+)
+
+// FileProvider provides content from the file system
+type FileProvider struct {
+	descriptor *sync.Map // map[string]ocispec.Descriptor
+}
+
+// NewFileProvider creats a new file provider
+func NewFileProvider() *FileProvider {
+	return nil
+}
+
+// Add adds a file reference
+func (p *FileProvider) Add(filename, mediaType string) error {
+	fileInfo, err := os.Stat(filename)
+	if err != nil {
+		return err
+	}
+	file, err := os.Open(filename)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+	digest, err := digest.FromReader(file)
+	if err != nil {
+		return err
+	}
+
+	desc := ocispec.Descriptor{
+		MediaType: mediaType,
+		Digest:    digest,
+		Size:      fileInfo.Size(),
+		Annotations: map[string]string{
+			ocispec.AnnotationTitle: filename,
+		},
+	}
+
+	p.descriptor.Store(desc.Digest, desc)
+	return nil
+}
+
+// ReaderAt provides contents
+func (p *FileProvider) ReaderAt(ctx context.Context, desc ocispec.Descriptor) (content.ReaderAt, error) {
+	value, ok := p.descriptor.Load(desc.Digest)
+	if !ok {
+		return nil, ErrNotFound
+	}
+	desc = value.(ocispec.Descriptor)
+	filename, ok := desc.Annotations[ocispec.AnnotationTitle]
+	file, err := os.Open(filename)
+	if err != nil {
+		return nil, err
+	}
+
+	return sizeReaderAt{
+		readAtCloser: file,
+		size:         desc.Size,
+	}, nil
+}

--- a/pkg/content/file.go
+++ b/pkg/content/file.go
@@ -27,8 +27,8 @@ type FileStore struct {
 	descriptor *sync.Map // map[string]ocispec.Descriptor
 }
 
-// NewFileProvider creats a new file provider
-func NewFileProvider(rootPath string) *FileStore {
+// NewFileStore creats a new file store
+func NewFileStore(rootPath string) *FileStore {
 	return &FileStore{
 		root:       rootPath,
 		descriptor: &sync.Map{},

--- a/pkg/content/file.go
+++ b/pkg/content/file.go
@@ -61,7 +61,7 @@ func (p *FileProvider) ReaderAt(ctx context.Context, desc ocispec.Descriptor) (c
 		return nil, ErrNotFound
 	}
 	desc = value.(ocispec.Descriptor)
-	filename, ok := desc.Annotations[ocispec.AnnotationTitle]
+	filename := desc.Annotations[ocispec.AnnotationTitle]
 	file, err := os.Open(filename)
 	if err != nil {
 		return nil, err

--- a/pkg/content/file.go
+++ b/pkg/content/file.go
@@ -36,20 +36,20 @@ func NewFileStore(rootPath string) *FileStore {
 }
 
 // Add adds a file reference
-func (s *FileStore) Add(name, mediaType string) error {
+func (s *FileStore) Add(name, mediaType string) (ocispec.Descriptor, error) {
 	path := s.resolvePath(name)
 	fileInfo, err := os.Stat(path)
 	if err != nil {
-		return err
+		return ocispec.Descriptor{}, err
 	}
 	file, err := os.Open(path)
 	if err != nil {
-		return err
+		return ocispec.Descriptor{}, err
 	}
 	defer file.Close()
 	digest, err := digest.FromReader(file)
 	if err != nil {
-		return err
+		return ocispec.Descriptor{}, err
 	}
 
 	desc := ocispec.Descriptor{
@@ -62,7 +62,7 @@ func (s *FileStore) Add(name, mediaType string) error {
 	}
 
 	s.set(desc)
-	return nil
+	return desc, nil
 }
 
 // ReaderAt provides contents

--- a/pkg/content/memory.go
+++ b/pkg/content/memory.go
@@ -80,7 +80,7 @@ func (s *Memorystore) Writer(ctx context.Context, opts ...content.WriterOpt) (co
 	}
 	desc := wOpts.Desc
 
-	name, _ := resolveName(desc)
+	name, _ := ResolveName(desc)
 	now := time.Now()
 	return &memoryWriter{
 		store:    s,

--- a/pkg/content/memory.go
+++ b/pkg/content/memory.go
@@ -44,6 +44,10 @@ func (s *Memorystore) Add(name, mediaType string, content []byte) ocispec.Descri
 		}
 	}
 
+	if mediaType == "" {
+		mediaType = DefaultBlobMediaType
+	}
+
 	desc := ocispec.Descriptor{
 		MediaType:   mediaType,
 		Digest:      digest.FromBytes(content),

--- a/pkg/content/memory.go
+++ b/pkg/content/memory.go
@@ -1,0 +1,180 @@
+package content
+
+import (
+	"bytes"
+	"context"
+	"sync"
+	"time"
+
+	"github.com/containerd/containerd/content"
+	"github.com/containerd/containerd/errdefs"
+	digest "github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/pkg/errors"
+)
+
+// ensure interface
+var (
+	_ content.Provider = &Memorytore{}
+	_ content.Ingester = &Memorytore{}
+)
+
+// Memorytore provides content from the memory
+type Memorytore struct {
+	descriptor map[digest.Digest]ocispec.Descriptor
+	content    map[digest.Digest][]byte
+	lock       *sync.Mutex
+}
+
+// NewMemoryStore creats a new memory store
+func NewMemoryStore() *Memorytore {
+	return &Memorytore{
+		descriptor: make(map[digest.Digest]ocispec.Descriptor),
+		content:    make(map[digest.Digest][]byte),
+		lock:       &sync.Mutex{},
+	}
+}
+
+// Add adds content
+func (s *Memorytore) Add(name, mediaType string, content []byte) {
+	var annotations map[string]string
+	if name != "" {
+		annotations = map[string]string{
+			ocispec.AnnotationTitle: name,
+		}
+	}
+
+	desc := ocispec.Descriptor{
+		MediaType:   mediaType,
+		Digest:      digest.FromBytes(content),
+		Size:        int64(len(content)),
+		Annotations: annotations,
+	}
+
+	s.set(desc, content)
+}
+
+// ReaderAt provides contents
+func (s *Memorytore) ReaderAt(ctx context.Context, desc ocispec.Descriptor) (content.ReaderAt, error) {
+	desc, content, ok := s.get(desc)
+	if !ok {
+		return nil, ErrNotFound
+	}
+
+	return sizeReaderAt{
+		readAtCloser: nopCloser{
+			ReaderAt: bytes.NewReader(content),
+		},
+		size: desc.Size,
+	}, nil
+}
+
+// Writer begins or resumes the active writer identified by desc
+func (s *Memorytore) Writer(ctx context.Context, opts ...content.WriterOpt) (content.Writer, error) {
+	var wOpts content.WriterOpts
+	for _, opt := range opts {
+		if err := opt(&wOpts); err != nil {
+			return nil, err
+		}
+	}
+	desc := wOpts.Desc
+
+	name, _ := resolveName(desc)
+	now := time.Now()
+	return &memoryWriter{
+		store:    s,
+		buffer:   bytes.NewBuffer(nil),
+		desc:     desc,
+		digester: digest.Canonical.Digester(),
+		status: content.Status{
+			Ref:       name,
+			Total:     desc.Size,
+			StartedAt: now,
+			UpdatedAt: now,
+		},
+	}, nil
+}
+func (s *Memorytore) set(desc ocispec.Descriptor, content []byte) {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	s.descriptor[desc.Digest] = desc
+	s.content[desc.Digest] = content
+}
+
+func (s *Memorytore) get(desc ocispec.Descriptor) (ocispec.Descriptor, []byte, bool) {
+	desc, ok := s.descriptor[desc.Digest]
+	if !ok {
+		return ocispec.Descriptor{}, nil, false
+	}
+	content, ok := s.content[desc.Digest]
+	return desc, content, ok
+}
+
+type memoryWriter struct {
+	store    *Memorytore
+	buffer   *bytes.Buffer
+	desc     ocispec.Descriptor
+	digester digest.Digester
+	status   content.Status
+}
+
+func (w *memoryWriter) Status() (content.Status, error) {
+	return w.status, nil
+}
+
+// Digest returns the current digest of the content, up to the current write.
+//
+// Cannot be called concurrently with `Write`.
+func (w *memoryWriter) Digest() digest.Digest {
+	return w.digester.Digest()
+}
+
+// Write p to the transaction.
+func (w *memoryWriter) Write(p []byte) (n int, err error) {
+	n, err = w.buffer.Write(p)
+	w.digester.Hash().Write(p[:n])
+	w.status.Offset += int64(len(p))
+	w.status.UpdatedAt = time.Now()
+	return n, err
+}
+
+func (w *memoryWriter) Commit(ctx context.Context, size int64, expected digest.Digest, opts ...content.Opt) error {
+	var base content.Info
+	for _, opt := range opts {
+		if err := opt(&base); err != nil {
+			return err
+		}
+	}
+
+	if w.buffer == nil {
+		return errors.Wrap(errdefs.ErrFailedPrecondition, "cannot commit on closed writer")
+	}
+	content := w.buffer.Bytes()
+	w.buffer = nil
+
+	if size > 0 && size != int64(len(content)) {
+		return errors.Wrapf(errdefs.ErrFailedPrecondition, "unexpected commit size %d, expected %d", len(content), size)
+	}
+	if dgst := w.digester.Digest(); expected != "" && expected != dgst {
+		return errors.Wrapf(errdefs.ErrFailedPrecondition, "unexpected commit digest %s, expected %s", dgst, expected)
+	}
+
+	w.store.set(w.desc, content)
+	return nil
+}
+
+func (w *memoryWriter) Close() error {
+	w.buffer = nil
+	return nil
+}
+
+func (w *memoryWriter) Truncate(size int64) error {
+	if size != 0 {
+		return ErrUnsupportedSize
+	}
+	w.status.Offset = 0
+	w.digester.Hash().Reset()
+	w.buffer.Truncate(0)
+	return nil
+}

--- a/pkg/content/readerat.go
+++ b/pkg/content/readerat.go
@@ -24,3 +24,11 @@ type sizeReaderAt struct {
 func (ra sizeReaderAt) Size() int64 {
 	return ra.size
 }
+
+type nopCloser struct {
+	io.ReaderAt
+}
+
+func (nopCloser) Close() error {
+	return nil
+}

--- a/pkg/content/readerat.go
+++ b/pkg/content/readerat.go
@@ -1,0 +1,26 @@
+package content
+
+import (
+	"io"
+
+	"github.com/containerd/containerd/content"
+)
+
+// ensure interface
+var (
+	_ content.ReaderAt = sizeReaderAt{}
+)
+
+type readAtCloser interface {
+	io.ReaderAt
+	io.Closer
+}
+
+type sizeReaderAt struct {
+	readAtCloser
+	size int64
+}
+
+func (ra sizeReaderAt) Size() int64 {
+	return ra.size
+}

--- a/pkg/content/utils.go
+++ b/pkg/content/utils.go
@@ -2,7 +2,8 @@ package content
 
 import ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 
-func resolveName(desc ocispec.Descriptor) (string, bool) {
+// ResolveName resolves name from descriptor
+func ResolveName(desc ocispec.Descriptor) (string, bool) {
 	name, ok := desc.Annotations[ocispec.AnnotationTitle]
 	return name, ok
 }

--- a/pkg/content/utils.go
+++ b/pkg/content/utils.go
@@ -1,0 +1,8 @@
+package content
+
+import ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+
+func resolveName(desc ocispec.Descriptor) (string, bool) {
+	name, ok := desc.Annotations[ocispec.AnnotationTitle]
+	return name, ok
+}

--- a/pkg/oras/consts.go
+++ b/pkg/oras/consts.go
@@ -4,9 +4,3 @@ import ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 
 // DefaultBlobMediaType specifies the default blob media type
 const DefaultBlobMediaType = ocispec.MediaTypeImageLayer
-
-// Blob refers a blob with a media type
-type Blob struct {
-	MediaType string
-	Content   []byte
-}

--- a/pkg/oras/errors.go
+++ b/pkg/oras/errors.go
@@ -4,7 +4,6 @@ import "errors"
 
 // Common errors
 var (
-	ErrNotFound          = errors.New("not_found")
 	ErrResolverUndefined = errors.New("resolver_undefined")
-	ErrEmptyBlobs        = errors.New("empty_blobs")
+	ErrEmptyDescriptors  = errors.New("empty_descriptors")
 )

--- a/pkg/oras/oras_test.go
+++ b/pkg/oras/oras_test.go
@@ -14,7 +14,9 @@ import (
 	"github.com/docker/distribution/configuration"
 	"github.com/docker/distribution/registry"
 	_ "github.com/docker/distribution/registry/storage/driver/inmemory"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/phayes/freeport"
+	orascontent "github.com/shizhMSFT/oras/pkg/content"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -64,41 +66,47 @@ func (suite *ORASTestSuite) SetupSuite() {
 
 // Push files to docker registry
 func (suite *ORASTestSuite) Test_0_Push() {
-	var err error
-	var ref string
-	var blobs map[string]Blob
+	var (
+		err         error
+		ref         string
+		desc        ocispec.Descriptor
+		descriptors []ocispec.Descriptor
+		store       *orascontent.FileStore
+	)
 
-	err = Push(newContext(), nil, ref, blobs)
+	err = Push(newContext(), nil, ref, nil, descriptors)
 	suite.NotNil(err, "error pushing with empty resolver")
 
-	err = Push(newContext(), newResolver(), ref, blobs)
+	err = Push(newContext(), newResolver(), ref, nil, descriptors)
 	suite.NotNil(err, "error pushing when context missing hostname")
 
 	ref = fmt.Sprintf("%s/empty:test", suite.DockerRegistryHost)
-	err = Push(newContext(), newResolver(), ref, blobs)
-	suite.NotNil(ErrEmptyBlobs, err, "error pushing with empty blobs")
+	err = Push(newContext(), newResolver(), ref, nil, descriptors)
+	suite.NotNil(ErrEmptyDescriptors, err, "error pushing with empty descriptors")
 
-	// Load blobs with test chart tgz (as single layer)
-	blobs = make(map[string]Blob)
-	content, err := ioutil.ReadFile(testTarball)
-	suite.Nil(err, "no error loading test chart")
+	// Load descriptors with test chart tgz (as single layer)
+	store = orascontent.NewFileStore("")
 	basename := filepath.Base(testTarball)
-	blobs[basename] = Blob{Content: content}
+	desc, err = store.Add(basename, "", testTarball)
+	suite.Nil(err, "no error loading test chart")
+	descriptors = []ocispec.Descriptor{desc}
 
 	ref = fmt.Sprintf("%s/chart-tgz:test", suite.DockerRegistryHost)
-	err = Push(newContext(), newResolver(), ref, blobs)
+	err = Push(newContext(), newResolver(), ref, store, descriptors)
 	suite.Nil(err, "no error pushing test chart tgz (as single layer)")
 
-	// Load blobs with test chart dir (each file as layer)
-	blobs = make(map[string]Blob)
+	// Load descriptors with test chart dir (each file as layer)
+	store = orascontent.NewFileStore(testDir)
+	descriptors = []ocispec.Descriptor{}
 	var ff = func(pathX string, infoX os.FileInfo, errX error) error {
 		if !infoX.IsDir() {
 			filename := filepath.Join(filepath.Dir(pathX), infoX.Name())
-			content, err := ioutil.ReadFile(filename)
+			name := filepath.ToSlash(filename)
+			desc, err = store.Add(name, "", filename)
 			if err != nil {
 				return err
 			}
-			blobs[filepath.ToSlash(filename)] = Blob{Content: content}
+			descriptors = append(descriptors, desc)
 		}
 		return nil
 	}
@@ -109,48 +117,59 @@ func (suite *ORASTestSuite) Test_0_Push() {
 	os.Chdir(cwd)
 
 	ref = fmt.Sprintf("%s/chart-dir:test", suite.DockerRegistryHost)
-	err = Push(newContext(), newResolver(), ref, blobs)
+	err = Push(newContext(), newResolver(), ref, store, descriptors)
 	suite.Nil(err, "no error pushing test chart dir (each file as layer)")
 }
 
-// Pull files and verify blobs
+// Pull files and verify descriptors
 func (suite *ORASTestSuite) Test_1_Pull() {
-	var err error
-	var ref string
-	var blobs map[string]Blob
+	var (
+		err         error
+		ref         string
+		descriptors []ocispec.Descriptor
+		store       *orascontent.Memorystore
+	)
 
-	blobs, err = Pull(newContext(), nil, ref)
+	descriptors, err = Pull(newContext(), nil, ref, nil)
 	suite.NotNil(err, "error pulling with empty resolver")
-	suite.Nil(blobs, "blobs nil pulling with empty resolver")
+	suite.Nil(descriptors, "descriptors nil pulling with empty resolver")
 
 	// Pull non-existant
+	store = orascontent.NewMemoryStore()
 	ref = fmt.Sprintf("%s/nonexistant:test", suite.DockerRegistryHost)
-	blobs, err = Pull(newContext(), newResolver(), ref)
+	descriptors, err = Pull(newContext(), newResolver(), ref, store)
 	suite.NotNil(err, "error pulling non-existant ref")
-	suite.Nil(blobs, "blobs empty with error")
+	suite.Nil(descriptors, "descriptors empty with error")
 
 	// Pull chart-tgz
+	store = orascontent.NewMemoryStore()
 	ref = fmt.Sprintf("%s/chart-tgz:test", suite.DockerRegistryHost)
-	blobs, err = Pull(newContext(), newResolver(), ref)
+	descriptors, err = Pull(newContext(), newResolver(), ref, store)
 	suite.Nil(err, "no error pulling chart-tgz ref")
 
-	// Verify the blobs, single layer/file
+	// Verify the descriptors, single layer/file
 	content, err := ioutil.ReadFile(testTarball)
 	suite.Nil(err, "no error loading test chart")
-	suite.Equal(content, blobs[filepath.Base(testTarball)].Content, ".tgz content matches on pull")
+	name := filepath.Base(testTarball)
+	_, actualContent, ok := store.GetByName(name)
+	suite.True(ok, "find in memory")
+	suite.Equal(content, actualContent, ".tgz content matches on pull")
 
 	// Pull chart-dir
+	store = orascontent.NewMemoryStore()
 	ref = fmt.Sprintf("%s/chart-dir:test", suite.DockerRegistryHost)
-	blobs, err = Pull(newContext(), newResolver(), ref)
+	descriptors, err = Pull(newContext(), newResolver(), ref, store)
 	suite.Nil(err, "no error pulling chart-dir ref")
 
-	// Verify the blobs, multiple layers/files
+	// Verify the descriptors, multiple layers/files
 	cwd, _ := os.Getwd()
 	os.Chdir(testDir)
 	for _, filename := range testDirFiles {
 		content, err = ioutil.ReadFile(filename)
 		suite.Nil(err, fmt.Sprintf("no error loading %s", filename))
-		suite.Equal(content, blobs[filename].Content, fmt.Sprintf("%s content matches on pull", filename))
+		_, actualContent, ok := store.GetByName(filename)
+		suite.True(ok, "find in memory")
+		suite.Equal(content, actualContent, fmt.Sprintf("%s content matches on pull", filename))
 	}
 	os.Chdir(cwd)
 }

--- a/pkg/oras/oras_test.go
+++ b/pkg/oras/oras_test.go
@@ -96,7 +96,9 @@ func (suite *ORASTestSuite) Test_0_Push() {
 	suite.Nil(err, "no error pushing test chart tgz (as single layer)")
 
 	// Load descriptors with test chart dir (each file as layer)
-	store = orascontent.NewFileStore(testDir)
+	testDirAbs, err := filepath.Abs(testDir)
+	suite.Nil(err, "no error parsing test directory")
+	store = orascontent.NewFileStore(testDirAbs)
 	descriptors = []ocispec.Descriptor{}
 	var ff = func(pathX string, infoX os.FileInfo, errX error) error {
 		if !infoX.IsDir() {

--- a/pkg/oras/push.go
+++ b/pkg/oras/push.go
@@ -17,7 +17,7 @@ func Push(ctx context.Context, resolver remotes.Resolver, ref string, provider c
 		return ErrResolverUndefined
 	}
 
-	if descriptors == nil {
+	if len(descriptors) == 0 {
 		return ErrEmptyDescriptors
 	}
 

--- a/pkg/oras/push.go
+++ b/pkg/oras/push.go
@@ -12,13 +12,13 @@ import (
 )
 
 // Push pushes files to the remote
-func Push(ctx context.Context, resolver remotes.Resolver, ref string, blobs map[string]Blob) error {
+func Push(ctx context.Context, resolver remotes.Resolver, ref string, provider content.Provider, descriptors []ocispec.Descriptor) error {
 	if resolver == nil {
 		return ErrResolverUndefined
 	}
 
-	if blobs == nil {
-		return ErrEmptyBlobs
+	if descriptors == nil {
+		return ErrEmptyDescriptors
 	}
 
 	pusher, err := resolver.Pusher(ctx, ref)
@@ -26,7 +26,7 @@ func Push(ctx context.Context, resolver remotes.Resolver, ref string, blobs map[
 		return err
 	}
 
-	desc, provider, err := pack(blobs)
+	desc, provider, err := pack(provider, descriptors)
 	if err != nil {
 		return err
 	}
@@ -34,8 +34,8 @@ func Push(ctx context.Context, resolver remotes.Resolver, ref string, blobs map[
 	return remotes.PushContent(ctx, pusher, desc, provider, nil)
 }
 
-func pack(blobs map[string]Blob) (ocispec.Descriptor, content.Provider, error) {
-	store := NewMemoryStore()
+func pack(provider content.Provider, descriptors []ocispec.Descriptor) (ocispec.Descriptor, content.Provider, error) {
+	store := newHybridStoreFromProvider(provider)
 
 	// Config
 	configBytes := []byte("{}")
@@ -46,32 +46,13 @@ func pack(blobs map[string]Blob) (ocispec.Descriptor, content.Provider, error) {
 	}
 	store.Set(config, configBytes)
 
-	// Layer
-	var layers []ocispec.Descriptor
-	for name, blob := range blobs {
-		mediaType := blob.MediaType
-		if mediaType == "" {
-			mediaType = DefaultBlobMediaType
-		}
-		layer := ocispec.Descriptor{
-			MediaType: mediaType,
-			Digest:    digest.FromBytes(blob.Content),
-			Size:      int64(len(blob.Content)),
-			Annotations: map[string]string{
-				ocispec.AnnotationTitle: name,
-			},
-		}
-		store.Set(layer, blob.Content)
-		layers = append(layers, layer)
-	}
-
 	// Manifest
 	manifest := ocispec.Manifest{
 		Versioned: specs.Versioned{
 			SchemaVersion: 2, // historical value. does not pertain to OCI or docker version
 		},
 		Config: config,
-		Layers: layers,
+		Layers: descriptors,
 	}
 	manifestBytes, err := json.Marshal(manifest)
 	if err != nil {


### PR DESCRIPTION
Introducing `MemoryStore` and `FileStore` to provide and ingester contents.

All intermediate files are stored in the memory, and other files can be fetched from any `content.Provider` or be stored in any `content.Ingester`.

fix #20 