### PR TITLE
Overwrite by default when pulling

### DIFF
--- a/cmd/oras/pull.go
+++ b/cmd/oras/pull.go
@@ -15,7 +15,7 @@ type pullOptions struct {
 	targetRef          string
 	allowedMediaTypes  []string
 	allowAllMediaTypes bool
-	overwrite          bool
+	keepOldFiles       bool
 	pathTraversal      bool
 	output             string
 	verbose            bool
@@ -50,7 +50,7 @@ Example - Pull all files, any media type:
 
 	cmd.Flags().StringArrayVarP(&opts.allowedMediaTypes, "media-type", "t", nil, "allowed media types to be pulled")
 	cmd.Flags().BoolVarP(&opts.allowAllMediaTypes, "allow-all", "a", false, "allow all media types to be pulled")
-	cmd.Flags().BoolVarP(&opts.overwrite, "force", "f", false, "allow overwrite on existing files")
+	cmd.Flags().BoolVarP(&opts.keepOldFiles, "keep-old-files", "k", false, "do not replace existing files when pulling, treat them as errors")
 	cmd.Flags().BoolVarP(&opts.pathTraversal, "allow-path-traversal", "T", false, "allow storing files out of the output directory")
 	cmd.Flags().StringVarP(&opts.output, "output", "o", "", "output directory")
 	cmd.Flags().BoolVarP(&opts.verbose, "verbose", "v", false, "verbose output")
@@ -73,7 +73,7 @@ func runPull(opts pullOptions) error {
 
 	resolver := newResolver(opts.username, opts.password)
 	store := content.NewFileStore(opts.output)
-	store.AllowOverwrite = opts.overwrite
+	store.DisableOverwrite = opts.keepOldFiles
 	store.AllowPathTraversalOnWrite = opts.pathTraversal
 	files, err := oras.Pull(context.Background(), resolver, opts.targetRef, store, opts.allowedMediaTypes...)
 	if err != nil {

--- a/pkg/content/content_test.go
+++ b/pkg/content/content_test.go
@@ -50,7 +50,6 @@ func (suite *ContentTestSuite) SetupSuite() {
 	err := ioutil.WriteFile(testFileName, testContent, 0644)
 	suite.Nil(err, "no error creating test file on disk")
 	testFileStore := NewFileStore(testDirRoot)
-	testFileStore.AllowOverwrite = true
 	_, err = testFileStore.Add(testRef, "", testFileName)
 	suite.Nil(err, "no error adding item to file store")
 	suite.TestFileStore = testFileStore

--- a/pkg/content/file.go
+++ b/pkg/content/file.go
@@ -24,7 +24,7 @@ var (
 
 // FileStore provides content from the file system
 type FileStore struct {
-	AllowOverwrite            bool
+	DisableOverwrite          bool
 	AllowPathTraversalOnWrite bool
 
 	root       string
@@ -130,7 +130,7 @@ func (s *FileStore) Writer(ctx context.Context, opts ...content.WriterOpt) (cont
 			return nil, ErrPathTraversalDisallowed
 		}
 	}
-	if !s.AllowOverwrite {
+	if s.DisableOverwrite {
 		if _, err := os.Stat(path); err == nil {
 			return nil, ErrOverwriteDisallowed
 		} else if !os.IsNotExist(err) {


### PR DESCRIPTION
It makes more sense to overwrite by default when pulling at the `tar` tool does.